### PR TITLE
WEBCLIENT-244 #Fixed issues 243 and 244

### DIFF
--- a/js-i2b2/cells/CRC/CRC_ctrlr_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_ctrlr_QryTool.js
@@ -76,7 +76,17 @@ function QueryToolController() {
         jQuery("#temporalUIToggleDiv").hide();                    //  hide temporal query mode toggle when clear is pressed.
         jQuery("#toggleTemporalQueryModeSpan").html("Switch to Advanced Temporal Query"); // reset toggle button text
         i2b2.CRC.view.QT.isShowingTemporalQueryUI        = false; //  tdw9: 1707c:show reset state, which is not temporal query
-        i2b2.CRC.view.QT.isShowingClassicTemporalQueryUI = false; 
+		i2b2.CRC.view.QT.isShowingClassicTemporalQueryUI = false; 
+		// reset tutorial
+		jQuery(".highlighted").removeClass("highlighted"); // remove all highlighteds if they are not already removed
+		jQuery("#simpleTemporalQueryPointyArrow").hide();
+		jQuery('#tutorialShowMeLink').hide();
+		jQuery("#populationLabel").hide();	
+		if (i2b2.CRC.view.QT.isTutorial)
+			i2b2.CRC.view.QT.toggleTutorial();
+		i2b2.CRC.view.QT.deleteAllEvents();		
+		i2b2.CRC.view.QT.resetTemporalQueryUI();
+		i2b2.CRC.view.QT.tutorialState = 0; // reset tutorial state
         // hide new temporal sequence UI
         jQuery("#outerTemporalSequenceUI").hide();
         jQuery("#populationLabel").hide();

--- a/js-i2b2/cells/CRC/CRC_view_QryTool.js
+++ b/js-i2b2/cells/CRC/CRC_view_QryTool.js
@@ -2130,15 +2130,23 @@ i2b2.CRC.view.QT.resetTutorialAtState = function()
             jQuery('#populationLabel').delay(1500).fadeOut(250).fadeIn(250).fadeOut(250).fadeIn(600, function()
             {
                 jQuery("#simpleTemporalQueryPointyArrow").fadeOut();
-                jQuery("#populationLabel ").css("height", "12px");
-                jQuery("#populationLabel ").addClass("highlighted");
-                jQuery('#tutorialShowMeLink').fadeIn();
+                jQuery("#populationLabel").css("height", "12px");
+                if (i2b2.CRC.view.QT.isTutorial) // if user turned off tutorial, do not do these
+                {
+                    jQuery("#populationLabel").addClass("highlighted");
+                    jQuery('#tutorialShowMeLink').fadeIn();
+                }
+                else
+                {
+                    jQuery("#populationLabel").hide();
+                    jQuery('#tutorialShowMeLink').hide();
+                }
             });
             break;
         case 8:
             jQuery("#simpleTemporalQueryPointyArrow").hide();
-            jQuery("#populationLabel ").css("height", "");
-            jQuery("#populationLabel ").removeClass("highlighted");            
+            jQuery("#populationLabel").css("height", "");
+            jQuery("#populationLabel").removeClass("highlighted");            
             i2b2.CRC.view.QT.updateTutorialText("9. A population is optional. By leaving it empty, the temporal search applies to every patient in the databse.");
             break;
         case 9:
@@ -2339,7 +2347,7 @@ i2b2.CRC.view.QT.showDialog = function(title, mainMsgHTML, subMsgHTML, userIconN
 
     // set icon via changing classnames
     jQuery("#QTDialogImage").removeClass();
-    var iconName = "ui-icon-notice";
+    var iconName = "ui-icon-alert";
     if (userIconName ) 
         iconName = userIconName;
     if (iconName === "=none=")


### PR DESCRIPTION
WEBCLIENT-243 #Corrected dialog image
Now dialogs use the icon that has the exclaimation point inside a triangle.

WEBCLIENT-244 #Tutorial now properly resets when user clicks on "clear"
Upon Clearing a query, the tutorial state and UI on the Temporal Query Simple mode are now both reset so that when user goes into Simple Temporal Query again, the tutorial is in it's initial state (tr=urned off), and all the UIs are reset.