### PR TITLE
Support for Expanded List of Lab Result Flags

### DIFF
--- a/js-i2b2/cells/CRC/ModLabValues/CRC_ModLabValues_config_data.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_ModLabValues_config_data.js
@@ -17,4 +17,32 @@ i2b2.ValueTypes.type = {
 	"DEFAULT" : "NUMBER",
 	"PPV" : "PPV"
 }
+
+i2b2.LabExpandedFlags = {};
+i2b2.LabExpandedFlags.type = {
+	abnormal: {name:'Abnormal' , value:'[A]'},
+	high: {name:'High' , value:'[H]'},
+	low: {name:'Low' , value:'[L]'},
+	crithigh: {name:'Critical High' , value:'[CH]'},
+	critlow: {name:'Critical Low' , value:'[CL]'}
+};
+i2b2.LabExpandedFlags.process = function(flagstouse) {
+	flagList = {};
+	flagList.flagType = '[N]';
+	flagList.flags = [{name:'Normal', value:'@'}];
 	
+	for (const[flag, flagInfo] of Object.entries(i2b2.LabExpandedFlags.type)) {
+		if(flagstouse.indexOf(flagInfo.value) >=0 ) {
+			flagList.flagType += flagInfo.value;
+			flagList.flags.push(flagInfo);
+		}
+	}
+	/* If we only have the normal flag, we don't need a flag list */
+	if(flagList.flags.length == 1) {
+		flagList.flagType = false;
+		delete flagList.flags;
+	}
+	
+	return flagList
+}
+

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_ENUM.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_ENUM.js
@@ -294,14 +294,20 @@ i2b2.CRC.view.ENUM = {
 		try { 
 			var t = i2b2.h.getXNodeVal(refXML, 'Flagstouse'); 
 			if (t) {
-				if (t == "A") {
-					dm.flagType = 'NA';
-					dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
-				} else if (t == "HL") {
-					dm.flagType = 'HL';
-					dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+				if(!i2b2.UI.cfg.useExpandedLabFlags) {
+					if (t == "A") {
+						dm.flagType = 'NA';
+						dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
+					} else if (t == "HL") {
+						dm.flagType = 'HL';
+						dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+					} else {
+						dm.flagType = false;
+					}
 				} else {
-					dm.flagType = false;
+					var t_flags = i2b2.LabExpandedFlags.process(t);
+					dm.flagType = t_flags.flagType;
+					dm.flags = t_flags.flags;
 				}
 			} else {
 				dm.flagType = false;

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER.js
@@ -394,14 +394,20 @@ i2b2.CRC.view.NUMBER = {
 		try { 
 			var t = i2b2.h.getXNodeVal(refXML, 'Flagstouse'); 
 			if (t) {
-				if (t == "A") {
-					dm.flagType = 'NA';
-					dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
-				} else if (t == "HL") {
-					dm.flagType = 'HL';
-					dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+				if(!i2b2.UI.cfg.useExpandedLabFlags) {
+					if (t == "A") {
+						dm.flagType = 'NA';
+						dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
+					} else if (t == "HL") {
+						dm.flagType = 'HL';
+						dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+					} else {
+						dm.flagType = false;
+					}
 				} else {
-					dm.flagType = false;
+					var t_flags = i2b2.LabExpandedFlags.process(t);
+					dm.flagType = t_flags.flagType;
+					dm.flags = t_flags.flags;
 				}
 			} else {
 				dm.flagType = false;

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_PPV.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_PPV.js
@@ -307,14 +307,20 @@ i2b2.CRC.view.PPV = {
 		try { 
 			var t = i2b2.h.getXNodeVal(refXML, 'Flagstouse'); 
 			if (t) {
-				if (t == "A") {
-					dm.flagType = 'NA';
-					dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
-				} else if (t == "HL") {
-					dm.flagType = 'HL';
-					dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+				if(!i2b2.UI.cfg.useExpandedLabFlags) {
+					if (t == "A") {
+						dm.flagType = 'NA';
+						dm.flags = [{name:'Normal', value:'@'},{name:'Abnormal', value:'A'}];
+					} else if (t == "HL") {
+						dm.flagType = 'HL';
+						dm.flags = [{name:'Normal', value:'@'},{name:'High', value:'H'},{name:'Low', value:'L'}];
+					} else {
+						dm.flagType = false;
+					}
 				} else {
-					dm.flagType = false;
+					var t_flags = i2b2.LabExpandedFlags.process(t);
+					dm.flagType = t_flags.flagType;
+					dm.flags = t_flags.flags;
 				}
 			} else {
 				dm.flagType = false;

--- a/js-i2b2/i2b2_ui_config.js
+++ b/js-i2b2/i2b2_ui_config.js
@@ -24,7 +24,8 @@ i2b2.UI.cfg = {
 								  Control the real obfuscation value from server in CRC properties. */
 	useFloorThreshold: false, /* [Default: false] If true, any result below floorThresholdNumber shows as 'Less Than {floorThresholdNumber}' */	  
 	floorThresholdNumber: 10, /* [Default: 10] Threshold for low number of results */
-	floorThresholdText: "Less Than " // [Default: "Less Than "] Text that is prefixed before floorThresholdNumber (include trailing space)
+	floorThresholdText: "Less Than ", // [Default: "Less Than "] Text that is prefixed before floorThresholdNumber (include trailing space)
+	useExpandedLabFlags: true
 };
 /* End Configuration */
 


### PR DESCRIPTION
Provides support for an expanded set of lab flag values. List can be easily modified by users to support their needs or expanded to the full set of HL7/LOINC flag values. The expanded list is toggleable via an added config setting in the i2b2_ui_config.js.

It appears that only numeric lab results have the flag functionality included so only those files were modified.