### PR TITLE
switched response status check from "OK" to 200

### DIFF
--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_ENUM.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_ENUM.js
@@ -32,7 +32,7 @@ i2b2.CRC.view.ENUM = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_ENUM.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE.js
@@ -39,7 +39,7 @@ i2b2.CRC.view.GENOTYPE = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_GENOTYPE.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_LRGSTR.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_LRGSTR.js
@@ -32,7 +32,7 @@ i2b2.CRC.view.LRGSTR = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_LRGSTR.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_NODATATYPE.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_NODATATYPE.js
@@ -32,7 +32,7 @@ i2b2.CRC.view.NODATATYPE = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_NODATATYPE.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER.js
@@ -32,7 +32,7 @@ i2b2.CRC.view.NUMBER = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_NUMBER.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_PPV.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_PPV.js
@@ -45,7 +45,7 @@ i2b2.CRC.view.PPV = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_PPV.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/CRC/ModLabValues/CRC_view_STR.js
+++ b/js-i2b2/cells/CRC/ModLabValues/CRC_view_STR.js
@@ -32,7 +32,7 @@ i2b2.CRC.view.STR = {
 		var url = "js-i2b2/cells/CRC/ModLabValues/CRC_view_STR.html";
 		var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 		console.dir(response);
-		if (response.transport.statusText=="OK") {
+		if (response.transport.status == 200) {
 			thisHTML = response.transport.responseText;
 		} else {
 			alert('A problem was encounter while loading the html for the value type!');

--- a/js-i2b2/cells/PLUGINMGR/PLUGINMGR_ctrlr_general.js
+++ b/js-i2b2/cells/PLUGINMGR/PLUGINMGR_ctrlr_general.js
@@ -118,7 +118,7 @@ i2b2.PLUGINMGR.ctrlr.main =
 			var url = i2b2[pluginCode].cfg.config.assetDir + i2b2[pluginCode].cfg.config.plugin.html.source;
 			var response = new Ajax.Request(url, {method: 'get', asynchronous: false});
 			console.dir(response);
-			if (response.transport.statusText=="OK") {
+			if (response.transport.status == 200) {
 				// load the html into the IFRAME
 				var doc = $('anaPluginIFRAME').contentDocument;
 				if (!doc) {var doc = $('anaPluginIFRAME').contentWindow.document; }


### PR DESCRIPTION
http/2 spec does not specify reason phrases, and therefore it doesn't require that statusText be returned in the header (https://stackoverflow.com/questions/41632077/why-is-the-statustext-of-my-xhr-empty/41637669#41637669).

There are several places in the CRC cell surrounding the setvalue javascript that reference the statusText which were failing on successful responses because the statusText was empty on servers returning http/2 protocols.

This pull request switches to checking against the status code instead.