### PR TITLE
Fixed error when password contains characters breaking XML syntax

### DIFF
--- a/js-i2b2/cells/PM/PM_ctrlr.js
+++ b/js-i2b2/cells/PM/PM_ctrlr.js
@@ -2,8 +2,16 @@
  * @projectDescription	Controller object for Project Management.
  * @inherits 	i2b2
  * @namespace	i2b2.PM
- * @version 	2.0
+ * @version 	2.1
  **/
+
+// ================================================================================================== //
+i2b2.PM.escapeXMLText = function(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+};
 
 // ================================================================================================== //
 i2b2.PM.doSamlLogin = function(service) {
@@ -128,6 +136,8 @@ i2b2.PM.doLogin = function() {
     // copy the selected domain info into our main data model
     let login_username = $("#PM-login-modal input[name='loginusr']").val();
     let login_password = $("#PM-login-modal input[name='loginpass']").val();
+	
+	let escaped_login_password = i2b2.PM.escapeXMLText(login_password);
 
     let domain = i2b2.PM.model.Domains[$("#PM-login-modal #logindomain").val()];
     if (domain) {
@@ -165,12 +175,12 @@ i2b2.PM.doLogin = function() {
         is_shrine: shrine_domain,
         project: login_project,
         username: login_username,
-        sec_pass_node: `<password>${login_password}</password>`
+        sec_pass_node: `<password>${escaped_login_password}</password>`
     };
     let transportOptions = {
         url: login_url,
         user: login_username,
-        password: `<password>${login_password}</password>`,
+        password: `<password>${escaped_login_password}</password>`,
         domain: login_domain,
         project: login_project
     };
@@ -194,23 +204,16 @@ i2b2.PM._processUserConfig = function (data) {
     let ieInCompatibilityMode = false;
     let ua = window.navigator.userAgent;
     let msie = ua.indexOf("MSIE ");
-    if (msie > 0) browserIsIE8 = true;
-    if (browserIsIE8) {
-        if (ua.indexOf("Trident/4.0") > -1) ieInCompatibilityMode = true;
-    }
-    if (!(window.ActiveXObject) && "ActiveXObject" in window) browserIsIE11 = true;
-
-    let xml = data.refXML;
-    if (data.error === true) {
-        let s = i2b2.h.XPath(xml, 'descendant::result_status/status[@type="ERROR"]');
-        if (s.length > 0) {
-            // we have a proper error msg
-            if (s[0].firstChild.nodeValue !== "Password Expired.") {
-                alert("ERROR: " + s[0].firstChild.nodeValue);
-                return false;
-            }
+    if (msie > 0)
+        browserIsIE8 = true;
+    if(browserIsIE8){
+        if (ua.indexOf("Trident/4.0") > -1) {
+            ieInCompatibilityMode = true;
         }
     }
+    if(!(window.ActiveXObject) && "ActiveXObject" in window)
+        browserIsIE11 = true;
+
 
     // save the valid data that was passed into the PM cell's data model
     i2b2.PM.model.login_username = data.msgParams.sec_user;
@@ -232,6 +235,7 @@ i2b2.PM._processUserConfig = function (data) {
     if (i2b2.PM.model.reLogin) {
         try { i2b2.PM.view.modal.login.hide(); } catch(e) {}
         i2b2.PM.model.reLogin = false;
+
         return;
     }
     i2b2.PM.model.otherAuthMethod = false;
@@ -253,11 +257,6 @@ i2b2.PM._processUserConfig = function (data) {
         }
     } catch(e) {}
 
-    try {
-        const email = i2b2.h.XPath(data.refXML, '//user/email')[0];
-        i2b2.PM.model.email = i2b2.h.getXNodeVal(email, 'email');
-    } catch(e) {}
-
     i2b2.PM.model.login_domain = data.msgParams.sec_domain;
     i2b2.PM.model.shrine_domain = Boolean.parseTo(data.msgParams.is_shrine);
     i2b2.PM.model.login_project = data.msgParams.sec_project;
@@ -270,6 +269,7 @@ i2b2.PM._processUserConfig = function (data) {
     i2b2.PM.removeLoginDialog();
 
     i2b2.PM.cfg.cellURL = i2b2.PM.model.url;  // remember the url
+    let xml = data.refXML;
 
     // copy any global params to i2b2.hive.model.params
     i2b2.hive.model.globalParams = {}
@@ -297,51 +297,37 @@ i2b2.PM._processUserConfig = function (data) {
         let projdetails = i2b2.h.XPath(projs[i], 'descendant-or-self::param[@name]');
         i2b2.PM.model.projects[code].details = {};
         for (let d=0; d<projdetails.length; d++) {
-            let paramId = projdetails[d].getAttribute('id');
             let paramName = projdetails[d].getAttribute('name');
             // BUG FIX - Firefox splits large values into multiple 4k text nodes... use Firefox-specific function to read concatenated value
             if (projdetails[d].textContent) {
-                i2b2.PM.model.projects[code].details[paramId] = {
-                    name: paramName,
-                    status: projdetails[d].getAttribute('status'),
-                    value: projdetails[d].textContent
-                };
+                i2b2.PM.model.projects[code].details[paramName] = projdetails[d].textContent;
             } else if (projdetails[d].firstChild) {
                 // BUG FIX - WEBCLIENT-118
                 if(((browserIsIE8 && ieInCompatibilityMode) || browserIsIE11) && paramName === "announcement")
-                    i2b2.PM.model.projects[code].details[paramId] = {
-                        name: paramName,
-                        status: projdetails[d].getAttribute('status'),
-                        value: projdetails[d].firstChild.nodeValue
-                    };
+                    i2b2.PM.model.projects[code].details[paramName] = projdetails[d].firstChild.nodeValue;
                 else
-                    i2b2.PM.model.projects[code].details[paramId] = {
-                        name: paramName,
-                        status: projdetails[d].getAttribute('status'),
-                        value: projdetails[d].firstChild.nodeValue.unescapeHTML()
-                    };
+                    i2b2.PM.model.projects[code].details[paramName] = projdetails[d].firstChild.nodeValue.unescapeHTML();
             }
         }
     }
 
      if (!i2b2.PM.model.isAdmin && i2b2.PM.model.admin_only) {
-        if (data.msgResponse === "") {
-            alert("The PM Cell is down or the address in the properties file is incorrect.");
-        } else {
+        if (data.msgResponse === "")
+                    alert("The PM Cell is down or the address in the properties file is incorrect.");
+        else
             alert("Requires ADMIN role, please contact your system administrator");
-        }
         try { i2b2.PM.view.modal.login.show(); } catch(e) {}
         return true;
     } else if (i2b2.PM.model.admin_only) {
         // default to the first project
         i2b2.PM.model.login_project = ""; //i2b2.h.XPath(projs[0], 'attribute::id')[0].nodeValue;
         i2b2.PM._processLaunchFramework();
-    } else if (projs.length === 0) {
+    } else 	if (projs.length === 0) {
         // show project selection dialog if needed
         // better error messages
         let s = i2b2.h.XPath(xml, 'descendant::result_status/status[@type="ERROR"]');
         if (s.length > 0) {
-            // we have a proper error msg (which was handled at the top unless the password was expired)
+            // we have a proper error msg
             try {
                 if (s[0].firstChild.nodeValue === "Password Expired.") {
                     i2b2.PM.view.changePassword.show(function(){
@@ -368,7 +354,14 @@ i2b2.PM._processUserConfig = function (data) {
         // default to the only project the user has access to
         i2b2.PM.model.login_project = i2b2.h.XPath(projs[0], 'attribute::id')[0].nodeValue;
         i2b2.PM.model.login_projectname = i2b2.h.getXNodeVal(projs[0], "name");
-         i2b2.PM.view.showAnnouncements();
+        try {
+            let announcement = i2b2.PM.model.projects[i2b2.PM.model.login_project].details.announcement;
+            if (announcement) {
+                i2b2.PM.view.modal.announcementDialog.showAnnouncement(announcement);
+                return;
+            }
+        } catch(e) {}
+        i2b2.PM._processLaunchFramework();
     } else {
         // display list of possible projects for the user to select
         i2b2.PM.view.showProjectSelectionModal();


### PR DESCRIPTION
This occurs when using LDAP/SSO and a password of users contains characters that break XML syntax, like `<`, `>` or `&`.
The now escaped characters will be unescaped in the core server.